### PR TITLE
Fix cmd_here.bat for directories with spaces in them

### DIFF
--- a/example/deployment/snowblossom/cmd_here.bat
+++ b/example/deployment/snowblossom/cmd_here.bat
@@ -1,3 +1,3 @@
 @echo off
 title Snowblossom
-start /B /D %cd%
+start /B /D "%cd%"


### PR DESCRIPTION
Tiny fix to help folks who put spaces in directory names.